### PR TITLE
bug fix in get_state

### DIFF
--- a/dqn/atari/agent.py
+++ b/dqn/atari/agent.py
@@ -193,8 +193,8 @@ class AgentOfAtari():
 
   def get_state(self, complete=False):
 
-    size = [self.state_size, self.state_size + 1][complete]
-    return torch.cat(list(self.history)[: size]).unsqueeze(0)
+    size = [1, 0][complete]
+    return torch.cat(list(self.history)[size:]).unsqueeze(0)
 
   def push_to_memory(self, states, action, reward, done):
 


### PR DESCRIPTION
This PR address the following logical bug in get_state. During `get_state(complete=False)` we should return the last `state_size` frames from agent.history. Previously we were returning the first `agent.state_size` frames. 

At `agent.optimize` we get the first `agent.state_size` frames as state and last `agent.state_size` frames for `next_state`